### PR TITLE
minor typo correction - changed natural inhibition to lateral inhibition - Update 09-1.md

### DIFF
--- a/docs/en/week09/09-1.md
+++ b/docs/en/week09/09-1.md
@@ -82,7 +82,7 @@ It is a regulariser. The term itself is not trained, it's fixed. It's just the L
 <center><img src="{{site.baseurl}}/images/week09/09-1/AS3giSt.jpg" width="400px" height="200px"/></center>
 **Fig 5:** Invariant Features through Lateral Inhibition
 
-Here, there is a linear decoder with square reconstruction error. There is a criterion in the energy. The matrix $S$ is either determined by hand or learned so as to maximise this term. If the terms in $S$ are positive and large, it implies that the system does not want $z_i$ and $z_j$ to be on at the same time. Thus, it is sort of a mutual inhibition (called natural inhibition in neuroscience). Thus, you try to find a value for $S$ that is as large as possible.
+Here, there is a linear decoder with square reconstruction error. There is a criterion in the energy. The matrix $S$ is either determined by hand or learned so as to maximise this term. If the terms in $S$ are positive and large, it implies that the system does not want $z_i$ and $z_j$ to be on at the same time. Thus, it is sort of a mutual inhibition (called lateral inhibition in neuroscience). Thus, you try to find a value for $S$ that is as large as possible.
 
 <center><img src="{{site.baseurl}}/images/week09/09-1/sszdGh0.png" width="400px"/></center>
 **Fig 6:** Invariant Features through Lateral Inhibition (Tree Form)


### PR DESCRIPTION
I am quite sure that Yann LeCun talked about lateral inhibition and "natural inhibition" wasn't mentioned.

So, I changed "natural inhibition" to "lateral inhibition" because that is what is being discussed here. It is also clear from the context.